### PR TITLE
[ci] Add commit naming policy

### DIFF
--- a/.github/workflows/commit_naming.yml
+++ b/.github/workflows/commit_naming.yml
@@ -1,0 +1,50 @@
+name: Commit Naming
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  naming:
+    name: Commit Naming
+    runs-on: ubuntu-latest
+    container: python:alpine
+    steps:
+      - name: Update environment
+        run: |
+          apk update
+          apk add --no-cache git less openssh
+
+      - name: Checkout (Pull Request)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Shallow fetch (Pull Request)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          git fetch --progress --shallow-exclude ${{ github.base_ref }} origin +${{ github.sha }}:refs/remotes/origin/${{ github.head_ref }}
+          git log --pretty=oneline
+
+      - name: Checkout (Push)
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@v2
+
+      - name: Install gitcc
+        run: |
+          cd ./helper/gitcc
+          pip install .
+
+      - name: Check commits (Pull Request)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          gitcc history --verbose ./
+
+      - name: Check commit (Push)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          gitcc commit ./

--- a/helper/gitcc/gitcc/main.py
+++ b/helper/gitcc/gitcc/main.py
@@ -1,0 +1,74 @@
+import sys
+from argparse import ArgumentParser
+
+from git import Repo, InvalidGitRepositoryError
+from gitcc.utility import check_branch, check_history, check_summary, check_commit
+
+
+def cmd_parser():
+    parser = ArgumentParser(prog="gitcc", description="")
+
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    parser_summary = subparsers.add_parser('summary', help='check the given summary text')
+    parser_summary.add_argument(dest='summary_text', metavar='text', help="text to check")
+
+    parser_commit = subparsers.add_parser('commit', help='check current commit')
+    parser_commit.add_argument(dest='repository', type=str, help='path to the repository')
+
+    parser_history = subparsers.add_parser('history', help='check the current branch history')
+    parser_history.add_argument(dest='repository', type=str, help='path to the repository')
+    parser_history.add_argument('--sha', dest='sha', type=str, default="", help='check until this commit (exclusive)')
+    parser_history.add_argument('--verbose', dest='verbose', action='store_true', help='print correct commits too')
+
+    parser_branch = subparsers.add_parser('branch',
+                                          help='check the current branch with an other branch common ancestor.'
+                                               'Is the same as gitcc history with git merge-base <source> <target>')
+    parser_branch.add_argument(dest='target_branch', type=str, metavar='target', help='target branch')
+    parser_branch.add_argument(dest='repository', type=str, help='path to the repository')
+    parser_branch.add_argument('--verbose', dest='verbose', action='store_true', help='print correct commits too')
+
+    return parser
+
+
+def main():
+    args = cmd_parser().parse_args(sys.argv[1:])
+
+    if args.command == 'summary':
+        msg = check_summary(args.summary_text)
+        if msg != "":
+            print(msg)
+            exit(1)
+        else:
+            print("Commit summary has the correct format!")
+            exit(0)
+
+    repo = None
+    success = False
+    try:
+        repo = Repo(args.repository)
+    except InvalidGitRepositoryError:
+        print("Given path is not a repository.")
+        exit(2)
+
+    if args.command == 'commit':
+        success, msg = check_commit(repo.head.commit)
+        print(msg)
+    else:
+        msgs = []
+        if args.command == 'history':
+            success, msgs = check_history(repo, args.sha, include_correct=args.verbose)
+        elif args.command == 'branch':
+            success, msgs = check_branch(repo, repo.head, args.target_branch, include_correct=args.verbose)
+        else:
+            print("Invalid command")
+            exit(1)
+        if success and len(msgs) == 0:
+            print("All commits have the correct format!")
+        else:
+            print('\n'.join(msgs))
+
+    if success:
+        exit(0)
+    else:
+        exit(1)

--- a/helper/gitcc/gitcc/utility.py
+++ b/helper/gitcc/gitcc/utility.py
@@ -1,0 +1,79 @@
+import re
+
+from git import Repo, Commit
+
+
+class RxSummary:
+    rx_parser: re.Pattern = re.compile(r"\[(.*)] (.*)")
+    rx_category: re.Pattern = re.compile(r"\*|(?:[a-z0-9]{2,}[\s|-]?)+")
+    rx_description: re.Pattern = re.compile(r"[A-Z0-9].+[^.!?,\s]")
+
+    def __init__(self, summary: str):
+        self.category_tag: str = ""
+        self.description_text: str = ""
+
+        match = self.rx_parser.fullmatch(summary)
+        if match is None:
+            return
+        self.category_tag = match.group(1)
+        self.description_text = match.group(2)
+
+    def valid_format(self) -> bool:
+        return self.category_tag != "" and self.description_text != ""
+
+    def valid_category_tag(self) -> bool:
+        return self.rx_category.fullmatch(self.category_tag)
+
+    def valid_description(self) -> bool:
+        return self.rx_description.fullmatch(self.description_text)
+
+
+def check_summary(summary: str) -> str:
+    check = RxSummary(summary)
+    if not check.valid_format():
+        return "Invalid format. It should be '[<tag>] <Good Description>'"
+
+    if not check.valid_category_tag():
+        return "Invalid category tag. It should be either a single '*' or completely lowercase " \
+               "letters or numbers, at least 2 characters long, other allowed characters are: '|', '-' and spaces."
+
+    if not check.valid_description():
+        return "Invalid description. It should start with an uppercase letter or number, " \
+               "should be not to short and should not end with a punctuation."
+
+    return ""
+
+
+def check_commit(commit: Commit) -> (bool, str):
+    msg = check_summary(commit.summary)
+    if msg == "":
+        return True, f"Correct | {commit.hexsha} - {commit.summary}"
+    else:
+        return False, f"Failure | {commit.hexsha} - {commit.summary}\n" \
+                      f"    Summary: {msg}"
+
+
+def check_history(repo: Repo, exit_sha: str = "", include_correct: bool = False) -> (bool, list[str]):
+    success = True
+    msgs = []
+    for commit in repo.iter_commits():
+        if commit.hexsha == exit_sha:
+            break
+        res, msg = check_commit(commit)
+        if not res or include_correct:
+            msgs.append(msg)
+        success = success and res
+    return success, msgs
+
+
+def check_branch(repo: Repo, source_branch: str, target_branch: str, include_correct: bool = False) -> (
+        bool, list[str]):
+    error_msgs = []
+
+    common_ancestors = repo.merge_base(source_branch, target_branch)
+    if len(common_ancestors) == 0:
+        error_msgs.append("ERROR: No common ancestor found")
+        return error_msgs
+
+    start_commit = common_ancestors[0]
+    return check_history(repo, exit_sha=start_commit, include_correct=include_correct)

--- a/helper/gitcc/setup.py
+++ b/helper/gitcc/setup.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+from setuptools import find_packages, setup
+
+setup(
+    name="GIT Commit Check",
+    version="1.0.0",
+    description="Check the commit summary",
+    long_description="",
+    long_description_content_type='text/x-rst',
+    author="Iceflower S",
+    author_email="iceflower@gmx.de",
+    license='MIT',
+    url="",
+    classifiers=[
+        'Programming Language :: Python :: 3.9',
+        'License :: OSI Approved :: MIT License',
+        'Development Status :: 5 - Production/Stable',
+        'Operating System :: OS Independent',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Environment :: Console',
+    ],
+    keywords='git commit naming checker',
+    packages=find_packages(include=['gitcc', 'gitcc.*']),
+    python_requires='>=3.9',
+    install_requires=[
+        "GitPython==3.1.14",
+    ],
+    zip_safe=True,
+    entry_points={
+        'console_scripts': [
+            'gitcc = gitcc.main:main',
+        ],
+    },
+)


### PR DESCRIPTION
It is pretty obvious that commit summaries should follow a specific pattern. It makes it a lot easier to find commits which you search for.
The specified format is something like `[sound] Updated the fox sound`.
The added workflow will check the commit on push and all commits of an PR.

This tool will **not** prevent the merge commit name to be `Merge pull request #xxx from yyyy`, you have to remember yourself to change the merge summary to `[merge] Bla bla`


### Format

`[<category>] <Description>`

The category text can only include lower case letters, numbers, `|`, `-` and spaces and must be at least two characters. If the commit applies to various topics e.g. sound and rendering you write `[sound|rendering]`.
The description should start with an capital letter or number and must contain at least two words.
No punctuation at the end of the description (less text = less to read)


### Examples
Valid commit summaries:
```
[ci] Fix ci
[editor] Add collision visualization
```

Invalid commit summaries:
```
 [inv] Iam invalid
[ci] Short
[other] I have a dot at the end.
[[to many brackets]] My description
[other] no capital letter at start
```

### FAQ

Why code it ourself?
    - It makes it a lot easier to configure what format we exactly want.
    - The tool itself is pretty small.
    - No similiar tool on the market.

Checks in detail:
``` python
    rx_parser: re.Pattern = re.compile(r"\[(.*)] (.*)")
    rx_category: re.Pattern = re.compile(r"\*|(?:[a-z0-9]{2,}[\s|-]?)+")
    rx_description: re.Pattern = re.compile(r"[A-Z0-9].+[^.!?,\s]")
```

I want to test locally if a summary text is ok:
```
cd ./helper/gitcc
pip install .
gitcc summary "[cat] My commit summary to check"
```

CMD

```
usage: gitcc [-h] {summary,commit,history,branch} ...

positional arguments:
  {summary,commit,history,branch}
    summary             check the given summary text
    commit              check current commit
    history             check the current branch history
    branch              check the current branch with an other branch common ancestor. Is the same as gitcc history with git merge-base <source> <target>
```

"Stolen" from [here](https://github.com/inexorgame/vulkan-renderer/pull/323)